### PR TITLE
"Add" button on right

### DIFF
--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -5,14 +5,12 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-      <div class="navbar-nav">
+      <div class="navbar-nav flex-fill">
         <router-link class="nav-link active" :to="{ path: '/' }">Home <span class="sr-only">(current)</span></router-link>
         <router-link class="nav-link" :to="{ path: '/pets/cats' }">Cats</router-link>
         <router-link class="nav-link" :to="{ path: '/pets/dogs' }">Dogs</router-link>
 
-        <form class="form-inline my-2 my-lg-0">
-          <router-link class="btn btn-primary" :to="{ path: '/add' }">Add</router-link>
-        </form>
+        <router-link class="btn btn-primary ml-auto" :to="{ path: '/add' }">Add</router-link>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Use `flex-fill` to make the navbar-nav fill the navbar-collapse

`ml-auto` to put a margin on the left side of the add button

See this MDN article:
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox#Alignment_and_auto_margins

![image](https://user-images.githubusercontent.com/57737/94190726-be8aa580-fe69-11ea-91d8-c84833ebcd69.png)
